### PR TITLE
[BE] 프로필 이미지 수정 시 이미지 파일 저장

### DIFF
--- a/src/main/java/com/OmObe/OmO/MyPage/controller/MyPageController.java
+++ b/src/main/java/com/OmObe/OmO/MyPage/controller/MyPageController.java
@@ -19,7 +19,9 @@ import org.springframework.data.domain.Slice;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
+import org.springframework.web.multipart.MultipartFile;
 
+import javax.annotation.Nullable;
 import javax.validation.Valid;
 import javax.validation.constraints.Positive;
 import java.util.ArrayList;
@@ -97,8 +99,8 @@ public class MyPageController {
     @PatchMapping("/profileImage/{memberId}")
     public ResponseEntity patchProfileImage(@Valid @PathVariable("memberId") Long memberId,
                                             @RequestHeader("Authorization") String token,
-                                            @Valid @RequestBody MemberDto.ProfileImagePatch dto) {
-        myPageService.updateProfileImage(memberId, dto, token);
+                                            @Nullable @RequestParam("image")MultipartFile file) {
+        myPageService.updateProfileImage(memberId, token, file);
 
         return new ResponseEntity<>(HttpStatus.OK);
     }

--- a/src/main/java/com/OmObe/OmO/member/entity/Member.java
+++ b/src/main/java/com/OmObe/OmO/member/entity/Member.java
@@ -70,6 +70,14 @@ public class Member {
     @Column
     private boolean isOAuth; // OAuth2 사용 여부
 
+    /* 프로필 이미지 변경 시 기존 이미지 파일을 지워야 하는데 oauth에서 받아온 이미지라면 이미지 파일이 없기 때문에
+       이미지 파일 존재 여부를 파악하기 위해 isExistFile을 통해 파악한다.
+       isExistFile - true : 이미지 파일 존재
+       isExistFile - false : 이미지 파일이 존재하지 않음. oauth 로그인 시 받아온 기본 이미지 url.
+     */
+    @Column
+    private boolean isExistFile; // oauth에서 제공된 기본 이미지가 아닌 사용자가 설정한 이미지 사용 여부 (default : false)
+
     @Enumerated(value = EnumType.STRING)
     @Column(length = 20, nullable = false)
     private MemberStatus memberStatus = MemberStatus.MEMBER_ACTIVE; // 회원 상태 -> 기본값은 활동 상태
@@ -195,6 +203,10 @@ public class Member {
 
     public void setMemberRole(MemberRole memberRole) {
         this.memberRole = memberRole;
+    }
+
+    public void setExistFile(boolean existFile) {
+        isExistFile = existFile;
     }
 
     public enum MemberRole{ // 사용자 권한 등급


### PR DESCRIPTION
- Member 엔티티에 이미지 파일 존재 여부를 파악하는 필드 추가(isExistFile). 해당 필드가 true면 이미지 파일이 존재, false면 존재하지 않음을 의미
- 프로필 이미지 저장 시 기존에 설정한 이미지 파일이 있다면 지우고 새로운 이미지 파일 저장
- todo : 이미지 파일 처리 관련 메서드가 ReviewService에 있어 해당 기능을 사용하기 위해 MyPageService에서는 ReviewService까지 의존해야 함. 추후 이미지 파일 처리 관련 기능만 따로 분리하여 사용할 것
