### PR TITLE
[BE] 닉네임 중복 검증 성공한 경우의 응답 메시지 설정

### DIFF
--- a/src/main/java/com/OmObe/OmO/exception/ExceptionCode.java
+++ b/src/main/java/com/OmObe/OmO/exception/ExceptionCode.java
@@ -5,7 +5,7 @@ import lombok.Getter;
 public enum ExceptionCode {
     MEMBER_NOT_FOUND(404, "Member not found. Please check the member ID and try again."),
     EMAIL_ALREADY_EXIST(404, "This Email is already exist. Please check the email"),
-    NICKNAME_ALREADY_EXIST(404, "This Email is already exist. Please check the nickname"),
+    NICKNAME_ALREADY_EXIST(404, "This Nickname is already exist. Please check the nickname"),
     BOARD_NOT_FOUND(404,"Missing Board"),
     COMMENT_NOT_FOUND(404,"Missing Comment"),
     PASSWORD_NOT_CORRECT(404, "Password is not correct. Pleas check the password"),

--- a/src/main/java/com/OmObe/OmO/member/controller/MemberController.java
+++ b/src/main/java/com/OmObe/OmO/member/controller/MemberController.java
@@ -5,6 +5,7 @@ import com.OmObe.OmO.member.entity.Member;
 import com.OmObe.OmO.member.mapper.MemberMapper;
 import com.OmObe.OmO.member.repository.MemberRepository;
 import com.OmObe.OmO.member.service.MemberService;
+import com.OmObe.OmO.response.ResponseDto;
 import org.apache.coyote.Response;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;
@@ -63,6 +64,8 @@ public class MemberController {
         // 닉네임 중복 검증 메서드 실행
         memberService.verifyExistsNickname(nickname.getNickname());
 
-        return new ResponseEntity<>(HttpStatus.OK);
+        // 닉네임 중복 검증 성공 시 상태 코드와 상태 메시지 설정
+        ResponseDto.Response response = new ResponseDto.Response(200, "사용 가능한 닉네임입니다.");
+        return new ResponseEntity<>(response, HttpStatus.OK);
     }
 }

--- a/src/main/java/com/OmObe/OmO/response/ResponseDto.java
+++ b/src/main/java/com/OmObe/OmO/response/ResponseDto.java
@@ -1,0 +1,18 @@
+package com.OmObe.OmO.response;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+// api 요청에 대한 status와 message 응답을 위한 dto 클래스
+public class ResponseDto {
+    @AllArgsConstructor
+    @NoArgsConstructor
+    @Getter
+    @Setter
+    public static class Response{
+        private int status; // 상태 코드
+        private String message; // 상태 메시지
+    }
+}


### PR DESCRIPTION
- 중복 닉네임 에러 ExceptionCode 오타 수정(Email -> Nickname)
- api 요청에 대한 상태 코드와 상태 메시지 응답을 위한 ResponseDto 클래스 추가
- 닉네임 중복 성공 시 상태 코드(200)와 상태 메시지("사용 가능한 닉네임입니다.)를 응답으로 주도록 설정