### PR TITLE
feat: build.gradle에 prometheus 의존성 설정

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -31,6 +31,9 @@ dependencies {
 	// spring actuator
 	implementation 'org.springframework.boot:spring-boot-starter-actuator'
 
+	// prometheus
+	implementation 'io.micrometer:micrometer-registry-prometheus'
+
 	// jsr305 - for NPE caused by @Nullable Annotation
 	implementation 'com.google.code.findbugs:jsr305:3.0.2'
 


### PR DESCRIPTION
설명
- spring boot 어플리케이션에서 발생하는 매트릭을 prometheus에서 수집하도록 하기 위한 의존성 설정입니다.



변경사항
- build.gradle에 의존성 코드가 추가되었습니다.