### PR TITLE
[BE] 리프레시 토큰을 이용한 액세스 토큰 재발급 로직 수정

### DIFF
--- a/src/main/java/com/OmObe/OmO/advice/GlobalExceptionAdvice.java
+++ b/src/main/java/com/OmObe/OmO/advice/GlobalExceptionAdvice.java
@@ -57,11 +57,4 @@ public class GlobalExceptionAdvice {
 //
 //        return response;
 //    }
-
-    @ExceptionHandler
-    public ErrorResponse handleException(Exception e) { // 구현 상의 오류로 인해 발생하는 예외 처리
-        final ErrorResponse response = ErrorResponse.of(HttpStatus.INTERNAL_SERVER_ERROR);
-
-        return response;
-    }
 }

--- a/src/main/java/com/OmObe/OmO/auth/config/SecurityConfiguration.java
+++ b/src/main/java/com/OmObe/OmO/auth/config/SecurityConfiguration.java
@@ -70,10 +70,10 @@ public class SecurityConfiguration {
                         .antMatchers(HttpMethod.PATCH, "/notice/**").hasRole("ADMIN")
                         .antMatchers(HttpMethod.DELETE, "/notice/**").hasRole("ADMIN")
                         .antMatchers(HttpMethod.POST, "/h2/**").permitAll() // todo: 테스트용 db 조회 -> 관리자 권한만 접근하도록 수정할 것
-                        .antMatchers(HttpMethod.GET, "/**").permitAll()
                         .antMatchers(HttpMethod.POST, "/signup").permitAll()
                         .antMatchers(HttpMethod.GET, "/board/**").permitAll()
                         .antMatchers(HttpMethod.POST, "/checkNickname").permitAll()
+                        .antMatchers(HttpMethod.GET, "/**").permitAll()
                         .anyRequest().authenticated()
                 ).oauth2Login(oauth2 -> oauth2 // oauth2 인증 활성화
                         .successHandler(new OAuth2MemberSuccessHandler(tokenService, oAuth2MemberService, authorityUtils, redisService,jwtTokenizer)));

--- a/src/main/java/com/OmObe/OmO/auth/filter/JwtVerificationFilter.java
+++ b/src/main/java/com/OmObe/OmO/auth/filter/JwtVerificationFilter.java
@@ -28,6 +28,7 @@ import javax.servlet.http.HttpServletResponse;
 import java.io.IOException;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 
 // jwt 검증 필터
 @Slf4j
@@ -47,48 +48,43 @@ public class JwtVerificationFilter extends OncePerRequestFilter { // request 당
 //            return;
 //        }
 
-        String accessToken = request.getHeader("Authorization").replace("Bearer ", "");
-        String isLogout = (String) redisTemplate.opsForValue().get(accessToken);
+        /**
+         * 1. 액세스 토큰이 존재하는 경우 액세스 토큰 검증
+         * 2. 리프레시 토큰이 존재하는 경우 리프레시 토큰 검증
+         */
+        // 1. 액세스 토큰이 존재하는 경우 액세스 토큰 검증
+//        String accessToken = request.getHeader("Authorization").replace("Bearer ", "");
+        if (request.getHeader("Authorization") != null) {
+            String accessToken = request.getHeader("Authorization").replace("Bearer ", "");
+            String isLogout = (String) redisTemplate.opsForValue().get(accessToken);
 
-        if (!StringUtils.isEmpty(isLogout)) { // redis에 AccessToken이 있다면 로그아웃된 토큰이므로 예외처리
-            log.info("# Invalid Token");
-            throw new JwtException("Invalid Token");
+            if (!StringUtils.isEmpty(isLogout)) { // redis에 AccessToken이 있다면 로그아웃된 토큰이므로 예외처리
+                log.info("# Invalid Token");
+                throw new JwtException("Invalid Token");
+            }
+
+            verificationToken(accessToken, request, response);
+
+            // access token으로 memberId 추출
+            Long memberId = getMemberIdFromAccessToken(accessToken);
+            // memberId를 이용해 찾은 Member 객체
+            Member findMember = memberRepository.findByMemberId(memberId)
+                    .orElseThrow(() -> new BusinessLogicException(ExceptionCode.MEMBER_NOT_FOUND));
+
+            // SecurityContext에 등록할 Member 객체
+            MemberLoginDto memberLoginDto = MemberLoginDto.builder()
+                    .email(findMember.getEmail())
+                    .memberRole(findMember.getMemberRole())
+                    .build();
+
+            // SecurityContext에 MemberLoginDto 객체 등록
+            setAuthenticationToContext(memberLoginDto);
         }
-
-        try{
-            Map<String, Object> claims = verifyJws(request); // jwt 검증
-        } catch (ExpiredJwtException ee) {
-            // 액세스 토큰이 만료된 경우
-            log.info("catch ExpiredJwtException");
-            throw new JwtException("ExpiredJwtException");
-
-
-        } catch (MalformedJwtException me) {
-            // JWT 토큰이 형식에 맞지 않는 경우
-            log.info("catch MalformedJwtException");
-            response.setStatus(HttpServletResponse.SC_UNAUTHORIZED);
-        //  TODO : "java.lang.IllegalStateException: getWriter() has already been called for this response"의 오류 원인
-            //response.getWriter().write("Invalid Access-Token");
-//            request.setAttribute("exception", me);
-            throw new JwtException("MalformedJwtException");
-        } catch (Exception e) {
-            request.setAttribute("exception", e);
+        // 2. 리프레시 토큰이 존재하는 경우 리프레시 토큰 검증
+        else{
+            String refreshToken = request.getHeader("Refresh");
+            verificationToken(refreshToken, request, response);
         }
-
-        // access token으로 memberId 추출
-        Long memberId = getMemberIdFromAccessToken(accessToken);
-        // memberId를 이용해 찾은 Member 객체
-        Member findMember = memberRepository.findByMemberId(memberId)
-                .orElseThrow(() -> new BusinessLogicException(ExceptionCode.MEMBER_NOT_FOUND));
-
-        // SecurityContext에 등록할 Member 객체
-        MemberLoginDto memberLoginDto = MemberLoginDto.builder()
-                .email(findMember.getEmail())
-                .memberRole(findMember.getMemberRole())
-                .build();
-
-        // SecurityContext에 MemberLoginDto 객체 등록
-        setAuthenticationToContext(memberLoginDto);
 
         filterChain.doFilter(request, response); // 다음 필터 호출
     }
@@ -96,8 +92,10 @@ public class JwtVerificationFilter extends OncePerRequestFilter { // request 당
     @Override
     protected boolean shouldNotFilter(HttpServletRequest request) throws ServletException {
         String authorization = request.getHeader("Authorization");
+        String refresh = request.getHeader("Refresh");
 
-        return authorization == null || !authorization.startsWith("Bearer"); // Authorization header 값이 "Bearer"로 시작한 경우에 해당 필터 수행
+        // Authorization header 값이 없고, "Bearer"로 시작하지 않은 경우나 Refresh header에 값이 없는 경우 해당 필터는 실행되지 않음
+        return (authorization == null || !authorization.startsWith("Bearer")) && (refresh == null);
     }
 
     // jwt 검증 메서드
@@ -126,5 +124,27 @@ public class JwtVerificationFilter extends OncePerRequestFilter { // request 당
                 new UsernamePasswordAuthenticationToken(memberLoginDto.getEmail(), null, authorities);
         // SecurityContext에 Authentication 객체 저장
         SecurityContextHolder.getContext().setAuthentication(authentication);
+    }
+
+    // 토큰 검증 메서드
+    private void verificationToken(String token, HttpServletRequest request, HttpServletResponse response) {
+        try{
+//            Map<String, Object> claims = verifyJws(request); // jwt 검증
+            jwtTokenizer.getClaims(token, jwtTokenizer.encodeBase64SecretKey(jwtTokenizer.getSecretKey()));
+        } catch (ExpiredJwtException ee) {
+            // 액세스 토큰이 만료된 경우
+            log.info("catch ExpiredJwtException");
+            throw new JwtException("ExpiredJwtException");
+
+        } catch (MalformedJwtException me) {
+            // JWT 토큰이 형식에 맞지 않는 경우
+            log.info("catch MalformedJwtException");
+            response.setStatus(HttpServletResponse.SC_UNAUTHORIZED);
+            //  TODO : "java.lang.IllegalStateException: getWriter() has already been called for this response"의 오류 원인
+            throw new JwtException("MalformedJwtException");
+
+        } catch (Exception e) {
+            request.setAttribute("exception", e);
+        }
     }
 }

--- a/src/main/java/com/OmObe/OmO/auth/refreshtoken/RefreshTokenController.java
+++ b/src/main/java/com/OmObe/OmO/auth/refreshtoken/RefreshTokenController.java
@@ -8,26 +8,29 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestHeader;
 import org.springframework.web.bind.annotation.RestController;
 
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
+import java.util.HashMap;
+import java.util.Map;
 
 @RestController
 @RequiredArgsConstructor
 @Slf4j
 public class RefreshTokenController {
-    private final JwtTokenizer jwtTokenizer;
-    private final TokenService tokenService;
     private final RefreshTokenService refreshTokenService;
 
     // 리프레시 토큰을 통한 액세스 토큰 재발급
     @GetMapping("/reissueToken")
-    public ResponseEntity<HttpStatus> reissueAccessToken(HttpServletRequest request, HttpServletResponse response) {
-        String refreshToken = request.getHeader("Refresh");
+    public ResponseEntity<HttpStatus> reissueAccessToken(@RequestHeader("Refresh") String refreshToken,
+                                                         HttpServletResponse response) {
 
-        String accessToken = "Bearer " + refreshTokenService.reissueToken(refreshToken);
-        response.setHeader("Authorization", accessToken);
+        Map<String, String> reissuedTokens = refreshTokenService.reissueToken(refreshToken);
+
+        response.setHeader("Authorization", "Bearer " + reissuedTokens.get("accessToken"));
+        response.setHeader("Refresh", reissuedTokens.get("refreshToken"));
 
         return new ResponseEntity<>(HttpStatus.CREATED);
     }

--- a/src/main/java/com/OmObe/OmO/auth/refreshtoken/RefreshTokenService.java
+++ b/src/main/java/com/OmObe/OmO/auth/refreshtoken/RefreshTokenService.java
@@ -9,15 +9,19 @@ import com.OmObe.OmO.member.repository.MemberRepository;
 import com.OmObe.OmO.redis.RedisService;
 import io.jsonwebtoken.Claims;
 import io.jsonwebtoken.Jws;
+import io.jsonwebtoken.JwtException;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.stereotype.Service;
 
+import java.time.Instant;
+import java.util.HashMap;
+import java.util.Map;
 import java.util.Optional;
+import java.util.concurrent.TimeUnit;
 
 @Service
 @RequiredArgsConstructor
-
 public class RefreshTokenService {
     private final RedisTemplate<String, String> redisTemplate;
     private final RedisService redisService;
@@ -27,30 +31,49 @@ public class RefreshTokenService {
 
     /**
      * <리프레시 토큰을 이용한 액세스 토큰 재발급>
+     * 리프레시 토큰을 통해 새로운 액세스 토큰과 새로운 리프레시 토큰을 발급받아 새로운 리프레시 토큰으로 다음 액세스 토큰 재발급 가능(Refresh Token Rotation)
      * 1. 액세스 토큰 재발급 요청에 담긴 리프레시 토큰을 통해 회원의 이메일 추출
-     * 2. 추출한 이메일의 회원의 리프레시 토큰이 redis에 저장되어 있는지 확인
+     * 2. 추출한 이메일의 회원의 리프레시 토큰이 redis에 저장되어 있는지 확인 & 요청 시 들어오는 refreshToken이 redis에 저장된 리프레시 토큰과 일치하는지 확인
      *  2-1. 저장되어 있으면 3번 과정 진행
      *  2-2. redis에 없으면 예외 처리 후 종료
-     * 3. 새로운 액세스 토큰 발급 후 기존 저장되어 있던 리프레시 토큰은 redis에서 제거
+     * 3. 새로운 액세스 토큰 발급 후 Map에 key : "accessToken, value : accessToken으로 저장
+     * 4. 기존에 저장되어 있던 리프레시 토큰은 redis에서 제거
+     * 5. 새로운 리프레시 토큰 발급 후 Map에 key : "refreshToken", value : refreshToken으로 저장
      */
-    public String reissueToken(String refreshToken) {
+    public Map<String, String> reissueToken(String refreshToken) {
         // 1. 액세스 토큰 재발급 요청에 담긴 리프레시 토큰을 통해 회원의 이메일 추출
         Jws<Claims> claims = jwtTokenizer.getClaims(refreshToken, jwtTokenizer.encodeBase64SecretKey(jwtTokenizer.getSecretKey()));
         String email = claims.getBody().getSubject();
+        Map<String, String> reissuedTokens = new HashMap<>();
 
         Optional<Member> optionalMember = memberRepository.findByEmail(email);
 
-        // 2. 추출한 이메일의 회원의 리프레시 토큰이 redis에 저장되어 있는지 확인
-        if (Boolean.TRUE.equals(redisTemplate.hasKey(email)) && optionalMember.isPresent()) {
+        String refreshTokenInRedis = (String) redisTemplate.opsForValue().get(email); // 현재 redis에 저장된 리프레시 토큰
+
+        // 2. 추출한 이메일의 회원의 리프레시 토큰이 redis에 저장되어 있는지 확인 & 요청 시 들어오는 refreshToken이 redis에 저장된 리프레시 토큰과 일치하는지 확인
+        if (Boolean.TRUE.equals(redisTemplate.hasKey(email)) && optionalMember.isPresent() && (refreshToken.equals(refreshTokenInRedis))) {
             // 2-1. 저장되어 있으면 3번 과정 진행
             Member member = optionalMember.get();
-            String accessToken = tokenService.delegateAccessToken(member);
 
-            // 3. 새로운 액세스 토큰 발급 후 기존 저장되어 있던 리프레시 토큰은 redis에서 제거
+            // 3. 새로운 액세스 토큰 발급 후 Map에 key : "accessToken, value : accessToken으로 저장
+            String accessToken = tokenService.delegateAccessToken(member);
+            reissuedTokens.put("accessToken", accessToken);
+
+            // 4. 기존에 저장되어 있던 리프레시 토큰은 redis에서 제거
             redisTemplate.delete(email);
-            return accessToken;
+
+            // 5. 새로운 리프레시 토큰 발급 후 Map에 key : "refreshToken", value : refreshToken으로 저장
+            String reissuedRefreshToken = tokenService.delegateRefreshToken(member);
+            reissuedTokens.put("refreshToken", reissuedRefreshToken);
+
+            // 6. 새로운 리프레시 토큰을 redis에 key : email, value : refreshToken 형식으로 저장
+            Long remainExpiration = tokenService.calculateExpiration(claims); // 리프레시 토큰 만료 시간
+            redisService.setRefreshToken(email, reissuedRefreshToken, remainExpiration);
+
+            return reissuedTokens;
 
             // 2-2. redis에 없으면 예외 처리 후 종료
         } else throw new BusinessLogicException(ExceptionCode.INVALID_TOKEN);
     }
+
 }


### PR DESCRIPTION
- 기존에 리프레시 토큰을 통해 액세스 토큰 재발급을 로그인 1회에 1번만 가능했던 것을 액세스 토큰 재발급 기능을 여러 번 사용할 수 있도록 수정
- 리프레시 토큰을 통해 액세스 토큰을 재발급 받을 때 액세스 토큰과 리프레시 토큰을 모두 새로 발급받아 이 후 액세스 토큰을 재발급 받을 때 새로 발급받은 리프레시 토큰을 이용해 액세스 토큰을 재발급
- 한 번 사용된 리프레시 토큰은 재사용 불가(redis 내에 저장된 리프레시 토큰과 요청으로 들어온 리프레시 토큰을 비교해 같을 때만 로직이 실행됨.)