### PR TITLE
[BE] : OAuth2 로그인 리펙토링

### DIFF
--- a/src/main/java/com/OmObe/OmO/auth/oauth/controller/KakaoController.java
+++ b/src/main/java/com/OmObe/OmO/auth/oauth/controller/KakaoController.java
@@ -22,6 +22,7 @@ import org.springframework.security.web.authentication.AuthenticationSuccessHand
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
+import reactor.core.publisher.Mono;
 
 import javax.servlet.ServletException;
 import javax.servlet.http.HttpServletRequest;
@@ -44,10 +45,15 @@ public class KakaoController {
 
     @GetMapping("/auth/kakao/callback")
     public ResponseEntity kakaoCallback(@RequestParam("code") String code, HttpServletRequest request, HttpServletResponse response) throws IOException, ServletException{
-        OAuthToken oAuthToken = kakaoOAuthService.tokenRequest(code); // 토큰 획득
-        log.info("code : {}", code);
 
-        KakaoProfile kakaoProfile = kakaoOAuthService.userInfoRequest(oAuthToken); // 사용자 정보 획득
+        /*
+        block()을 사용하면 OAuth 인증 로직에 사용된 WebClient의 non-blocking 이점을 얻기 어렵지만, 사용자 인증로직(OAuth2MemberSuccessHandler, OAuth2AuhenticationToken)이
+        정상적으로 동작하는지 안정성 검증이 되지 않았고, WebClient의 이점을 모두 살리려면 나머지 로직의 수정이 필요할 수 있음.
+        oauth 토큰 획득과 토큰을 통한 사용자 정보 획득을 block() 처리하여 기존 RestTemplate을 사용했을 때의 로직 처리 흐름을 그대로 가져감.
+        단순히 deprecated된 RestTemplate을 대체하기 위한 목적으로 WebClient를 적용.
+        */
+        OAuthToken oAuthToken = kakaoOAuthService.tokenRequest(code).block(); // 토큰 획득
+        KakaoProfile kakaoProfile = kakaoOAuthService.userInfoRequest(oAuthToken).block(); // 사용자 정보 획득
 
         Map<String, Object> attributes = new HashMap<>();
         attributes.put("id", kakaoProfile.getId());

--- a/src/main/java/com/OmObe/OmO/auth/oauth/controller/NaverController.java
+++ b/src/main/java/com/OmObe/OmO/auth/oauth/controller/NaverController.java
@@ -46,10 +46,10 @@ public class NaverController {
     public ResponseEntity naverCallback(@RequestParam("code") String code,
                                         @RequestParam("state") String state,
                                         HttpServletRequest request, HttpServletResponse response) throws IOException, ServletException {
-        OAuthToken oAuthToken = naverOAuthService.tokenRequest(code); // 토큰 획득
+        OAuthToken oAuthToken = naverOAuthService.tokenRequest(code).block(); // 토큰 획득
         log.info("code : {}", code);
 
-        NaverProfile naverProfile = naverOAuthService.userInfoRequest(oAuthToken); // 사용자 정보 획득
+        NaverProfile naverProfile = naverOAuthService.userInfoRequest(oAuthToken).block(); // 사용자 정보 획득
 
         Map<String, Object> attributes = new HashMap<>();
         attributes.put("id", naverProfile.getResponse().getId());

--- a/src/main/java/com/OmObe/OmO/auth/oauth/controller/NaverController.java
+++ b/src/main/java/com/OmObe/OmO/auth/oauth/controller/NaverController.java
@@ -46,8 +46,13 @@ public class NaverController {
     public ResponseEntity naverCallback(@RequestParam("code") String code,
                                         @RequestParam("state") String state,
                                         HttpServletRequest request, HttpServletResponse response) throws IOException, ServletException {
+       /*
+        block()을 사용하면 OAuth 인증 로직에 사용된 WebClient의 non-blocking 이점을 얻기 어렵지만, 사용자 인증로직(OAuth2MemberSuccessHandler, OAuth2AuhenticationToken)이
+        정상적으로 동작하는지 안정성 검증이 되지 않았고, WebClient의 이점을 모두 살리려면 나머지 로직의 수정이 필요할 수 있음.
+        oauth 토큰 획득과 토큰을 통한 사용자 정보 획득을 block() 처리하여 기존 RestTemplate을 사용했을 때의 로직 처리 흐름을 그대로 가져감.
+        단순히 deprecated된 RestTemplate을 대체하기 위한 목적으로 WebClient를 적용.
+        */
         OAuthToken oAuthToken = naverOAuthService.tokenRequest(code).block(); // 토큰 획득
-        log.info("code : {}", code);
 
         NaverProfile naverProfile = naverOAuthService.userInfoRequest(oAuthToken).block(); // 사용자 정보 획득
 

--- a/src/main/java/com/OmObe/OmO/auth/oauth/service/KakaoOAuthService.java
+++ b/src/main/java/com/OmObe/OmO/auth/oauth/service/KakaoOAuthService.java
@@ -33,8 +33,6 @@ public class KakaoOAuthService {
 
     // 카카오 api 통해 액세스 토큰 요청
     public Mono<OAuthToken> tokenRequest(String code) {
-        log.info("clientId : {}", clientId);
-
         // kakao api 엔드포인트를 통해 액세스 토큰 요청을 보내고 응답을 받음
         return webClient.post()
                 .uri("https://kauth.kakao.com/oauth/token")
@@ -46,7 +44,6 @@ public class KakaoOAuthService {
 
     // kakao api로 사용자의 정보 요청
     public Mono<KakaoProfile> userInfoRequest(OAuthToken oAuthToken) {
-
         // kakao api 엔드포인트를 통해 액세스 토큰 요청을 보내고 응답을 받음
         return webClient.post()
                 .uri("https://kapi.kakao.com/v2/user/me")

--- a/src/main/java/com/OmObe/OmO/auth/oauth/service/KakaoOAuthService.java
+++ b/src/main/java/com/OmObe/OmO/auth/oauth/service/KakaoOAuthService.java
@@ -62,7 +62,7 @@ public class KakaoOAuthService {
         body.add("grant_type", "authorization_code");
         body.add("client_id", clientId);
         body.add("client_secret", clientSecret);
-        body.add("redirect_uri", "http://localhost:8080/auth/kakao/callback");
+        body.add("redirect_uri", "https://api.oneulmohae.co.kr/auth/kakao/callback");
         body.add("code", code);
 
         return body;

--- a/src/main/java/com/OmObe/OmO/auth/oauth/service/NaverOAuthService.java
+++ b/src/main/java/com/OmObe/OmO/auth/oauth/service/NaverOAuthService.java
@@ -34,8 +34,6 @@ public class NaverOAuthService {
 
     // 네이버 api 통해 액세스 토큰 요청
     public Mono<OAuthToken> tokenRequest(String code) {
-        log.info("clientId : {}", clientId);
-
         // kakao api 엔드포인트를 통해 액세스 토큰 요청을 보내고 응답을 받음
         return webClient.post()
                 .uri("https://nid.naver.com/oauth2.0/token")
@@ -44,32 +42,7 @@ public class NaverOAuthService {
                 .retrieve()
                 .bodyToMono(OAuthToken.class);
     }
-//    public OAuthToken tokenRequest(String code) {
-//        RestTemplate restTemplate = new RestTemplate();
-//
-//        // Http Header 설정
-//        HttpHeaders headers = new HttpHeaders();
-//        headers.add("Content-type", "application/x-www-form-urlencoded;charset=utf-8");
-//
-//        // Http Body 설정
-//        MultiValueMap<String, String> body = new LinkedMultiValueMap<>();
-//        body.add("grant_type", "authorization_code");
-//        body.add("client_id", clientId);
-//        body.add("client_secret", clientSecret);
-//        body.add("redirect_uri", "https://api.oneulmohae.co.kr/auth/naver/callback");
-//        body.add("code", code);
-//
-//        // HttpHeader와 HttpBody로 액세스 토큰 요청하는 객체 생성
-//        HttpEntity<MultiValueMap<String, String>> naverTokenRequest = new HttpEntity<>(body, headers);
-//
-//        // naver api 엔드포인트를 통해 액세스 토큰 요청을 보내고 응답을 받음
-//        return restTemplate.exchange(
-//                "https://nid.naver.com/oauth2.0/token",
-//                HttpMethod.POST,
-//                naverTokenRequest,
-//                OAuthToken.class
-//                ).getBody();
-//    }
+
 
     // naver api로 사용자의 정보 요청
     public Mono<NaverProfile> userInfoRequest(OAuthToken oAuthToken) {
@@ -82,25 +55,6 @@ public class NaverOAuthService {
                 .retrieve()
                 .bodyToMono(NaverProfile.class);
     }
-//    public NaverProfile userInfoRequest(OAuthToken oAuthToken) {
-//        RestTemplate restTemplate = new RestTemplate();
-//
-//        // Http Header 설정
-//        HttpHeaders httpHeaders = new HttpHeaders();
-//        httpHeaders.add("Authorization", "Bearer " + oAuthToken.getAccess_token());
-//        httpHeaders.add("Content_type", "application/x-www-form-urlencoded;charset=utf-8");
-//
-//        // HttpHeader와 HttpBody로 액세스 토큰 요청하는 객체 생성
-//        HttpEntity<MultiValueMap<String, String>> naverProfileRequest = new HttpEntity<>(httpHeaders);
-//
-//        // naver api 엔드포인트를 통해 액세스 토큰 요청을 보내고 응답을 받음
-//        return restTemplate.exchange(
-//                "https://openapi.naver.com/v1/nid/me",
-//                HttpMethod.POST,
-//                naverProfileRequest,
-//                NaverProfile.class
-//                ).getBody();
-//    }
 
     // 토큰 요청에 필요한 Body 생성
     private MultiValueMap<String, String> createTokenRequestBody(String code) {

--- a/src/main/java/com/OmObe/OmO/auth/oauth/service/NaverOAuthService.java
+++ b/src/main/java/com/OmObe/OmO/auth/oauth/service/NaverOAuthService.java
@@ -11,64 +11,106 @@ import org.springframework.stereotype.Service;
 import org.springframework.util.LinkedMultiValueMap;
 import org.springframework.util.MultiValueMap;
 import org.springframework.web.client.RestTemplate;
-
+import org.springframework.web.reactive.function.client.WebClient;
+import reactor.core.publisher.Mono;
 
 
 @Service
 @Slf4j
 public class NaverOAuthService {
+    private final WebClient webClient;
+
     @Value("${spring.security.oauth2.client.registration.naver.client-id}")
     private String clientId;
 
     @Value("${spring.security.oauth2.client.registration.naver.client-secret}")
     private String clientSecret;
 
+    public NaverOAuthService() {
+        this.webClient = WebClient.builder()
+                .defaultHeader("Content-type", "application/x-www-form-urlencoded;charset=utf-8")
+                .build();
+    }
+
     // 네이버 api 통해 액세스 토큰 요청
-    public OAuthToken tokenRequest(String code) {
-        RestTemplate restTemplate = new RestTemplate();
+    public Mono<OAuthToken> tokenRequest(String code) {
+        log.info("clientId : {}", clientId);
 
-        // Http Header 설정
-        HttpHeaders headers = new HttpHeaders();
-        headers.add("Content-type", "application/x-www-form-urlencoded;charset=utf-8");
+        // kakao api 엔드포인트를 통해 액세스 토큰 요청을 보내고 응답을 받음
+        return webClient.post()
+                .uri("https://nid.naver.com/oauth2.0/token")
+                .bodyValue(createTokenRequestBody(code))// 요청 body 설정
+                // 응답을 Mono<OAuthToken> 형태로 변환
+                .retrieve()
+                .bodyToMono(OAuthToken.class);
+    }
+//    public OAuthToken tokenRequest(String code) {
+//        RestTemplate restTemplate = new RestTemplate();
+//
+//        // Http Header 설정
+//        HttpHeaders headers = new HttpHeaders();
+//        headers.add("Content-type", "application/x-www-form-urlencoded;charset=utf-8");
+//
+//        // Http Body 설정
+//        MultiValueMap<String, String> body = new LinkedMultiValueMap<>();
+//        body.add("grant_type", "authorization_code");
+//        body.add("client_id", clientId);
+//        body.add("client_secret", clientSecret);
+//        body.add("redirect_uri", "https://api.oneulmohae.co.kr/auth/naver/callback");
+//        body.add("code", code);
+//
+//        // HttpHeader와 HttpBody로 액세스 토큰 요청하는 객체 생성
+//        HttpEntity<MultiValueMap<String, String>> naverTokenRequest = new HttpEntity<>(body, headers);
+//
+//        // naver api 엔드포인트를 통해 액세스 토큰 요청을 보내고 응답을 받음
+//        return restTemplate.exchange(
+//                "https://nid.naver.com/oauth2.0/token",
+//                HttpMethod.POST,
+//                naverTokenRequest,
+//                OAuthToken.class
+//                ).getBody();
+//    }
 
-        // Http Body 설정
+    // naver api로 사용자의 정보 요청
+    public Mono<NaverProfile> userInfoRequest(OAuthToken oAuthToken) {
+
+        // kakao api 엔드포인트를 통해 액세스 토큰 요청을 보내고 응답을 받음
+        return webClient.post()
+                .uri("https://openapi.naver.com/v1/nid/me")
+                .header("Authorization", "Bearer " + oAuthToken.getAccess_token()) // Http Header 설정
+                // 응답을 Mono<KakaoProfile> 형태로 변환
+                .retrieve()
+                .bodyToMono(NaverProfile.class);
+    }
+//    public NaverProfile userInfoRequest(OAuthToken oAuthToken) {
+//        RestTemplate restTemplate = new RestTemplate();
+//
+//        // Http Header 설정
+//        HttpHeaders httpHeaders = new HttpHeaders();
+//        httpHeaders.add("Authorization", "Bearer " + oAuthToken.getAccess_token());
+//        httpHeaders.add("Content_type", "application/x-www-form-urlencoded;charset=utf-8");
+//
+//        // HttpHeader와 HttpBody로 액세스 토큰 요청하는 객체 생성
+//        HttpEntity<MultiValueMap<String, String>> naverProfileRequest = new HttpEntity<>(httpHeaders);
+//
+//        // naver api 엔드포인트를 통해 액세스 토큰 요청을 보내고 응답을 받음
+//        return restTemplate.exchange(
+//                "https://openapi.naver.com/v1/nid/me",
+//                HttpMethod.POST,
+//                naverProfileRequest,
+//                NaverProfile.class
+//                ).getBody();
+//    }
+
+    // 토큰 요청에 필요한 Body 생성
+    private MultiValueMap<String, String> createTokenRequestBody(String code) {
         MultiValueMap<String, String> body = new LinkedMultiValueMap<>();
         body.add("grant_type", "authorization_code");
         body.add("client_id", clientId);
         body.add("client_secret", clientSecret);
-        body.add("redirect_uri", "https://api.oneulmohae.co.kr/auth/naver/callback");
+        body.add("redirect_uri", "https://api.oneulmohae.co.kr/auth/kakao/callback");
         body.add("code", code);
 
-        // HttpHeader와 HttpBody로 액세스 토큰 요청하는 객체 생성
-        HttpEntity<MultiValueMap<String, String>> naverTokenRequest = new HttpEntity<>(body, headers);
-
-        // naver api 엔드포인트를 통해 액세스 토큰 요청을 보내고 응답을 받음
-        return restTemplate.exchange(
-                "https://nid.naver.com/oauth2.0/token",
-                HttpMethod.POST,
-                naverTokenRequest,
-                OAuthToken.class
-                ).getBody();
-    }
-
-    // naver api로 사용자의 정보 요청
-    public NaverProfile userInfoRequest(OAuthToken oAuthToken) {
-        RestTemplate restTemplate = new RestTemplate();
-
-        // Http Header 설정
-        HttpHeaders httpHeaders = new HttpHeaders();
-        httpHeaders.add("Authorization", "Bearer " + oAuthToken.getAccess_token());
-        httpHeaders.add("Content_type", "application/x-www-form-urlencoded;charset=utf-8");
-
-        // HttpHeader와 HttpBody로 액세스 토큰 요청하는 객체 생성
-        HttpEntity<MultiValueMap<String, String>> naverProfileRequest = new HttpEntity<>(httpHeaders);
-
-        // naver api 엔드포인트를 통해 액세스 토큰 요청을 보내고 응답을 받음
-        return restTemplate.exchange(
-                "https://openapi.naver.com/v1/nid/me",
-                HttpMethod.POST,
-                naverProfileRequest,
-                NaverProfile.class
-                ).getBody();
+        return body;
     }
 }


### PR DESCRIPTION
- Spring 5.0 이후 deprecated된 RestTemplate 대신 WebClient를 사용한 코드로 변경
- WebClient의 non-blocking 및 비동기 처리에 대한 이점을 얻기 위해서는 로그인 로직과 관련된 다른 인증 로직의 안정성 검사가 필요하고, 다른 연관 로직의 수정이 필요할 수 있어 WebClient로 교체했지만 RestTemplate을 사용했을 때의 로직 처리흐름을 그대로 이용함.