### PR TITLE
[BE] memberId를 RequestHeader로 받는 요청 수정

### DIFF
--- a/src/main/java/com/OmObe/OmO/MyPage/controller/MyPageController.java
+++ b/src/main/java/com/OmObe/OmO/MyPage/controller/MyPageController.java
@@ -125,11 +125,11 @@ public class MyPageController {
     }
 
     // 프로필 이미지 수정
-    @PatchMapping("/profileImage/{memberId}")
-    public ResponseEntity patchProfileImage(@Valid @PathVariable("memberId") Long memberId,
-                                            @RequestHeader("Authorization") String token,
+    @PatchMapping("/profileImage")
+    public ResponseEntity patchProfileImage(@RequestHeader("Authorization") String token,
                                             @Nullable @RequestParam("image")MultipartFile file) {
-        Member member = myPageService.updateProfileImage(memberId, token, file);
+        Member findMember = tokenDecryption.getWriterInJWTToken(token); // token으로 Member 추출
+        Member member = myPageService.updateProfileImage(findMember.getMemberId(), token, file);
 
         // 수정한 프로필 이미지의 파일명을 응답으로 제공
         MyPageDto.profileImageResponse profileImageResponse = mapper.memberToProfileImageName(member);
@@ -137,30 +137,30 @@ public class MyPageController {
     }
 
     // 닉네임 수정
-    @PatchMapping("/nickname/{memberId}")
-    public ResponseEntity patchNickname(@Valid @PathVariable("memberId") Long memberId,
-                                        @RequestHeader("Authorization") String token,
+    @PatchMapping("/nickname")
+    public ResponseEntity patchNickname(@RequestHeader("Authorization") String token,
                                         @Valid @RequestBody MemberDto.NicknamePatch dto) {
-        myPageService.updateNickname(memberId, dto, token);
+        Member member = tokenDecryption.getWriterInJWTToken(token); // token으로 Member 추출
+        myPageService.updateNickname(member.getMemberId(), dto, token);
 
         return new ResponseEntity<>(HttpStatus.OK);
     }
 
     // MBTI 수정
-    @PatchMapping("/mbti/{memberId}")
-    public ResponseEntity patchMbti(@Valid @PathVariable("memberId") Long memberId,
-                                    @RequestHeader("Authorization") String token,
+    @PatchMapping("/mbti")
+    public ResponseEntity patchMbti(@RequestHeader("Authorization") String token,
                                     @Valid @RequestBody MemberDto.MbtiPatch dto) {
-        myPageService.updateMbti(memberId, dto, token);
+        Member member = tokenDecryption.getWriterInJWTToken(token); // token으로 Member 추출
+        myPageService.updateMbti(member.getMemberId(), dto, token);
 
         return new ResponseEntity<>(HttpStatus.OK);
     }
 
     // 내 정보 조회
-    @GetMapping("/myInfo/{memberId}")
-    public ResponseEntity getMyInfo(@Valid @PathVariable("memberId") Long memberId,
-                                    @RequestHeader("Authorization") String token) {
-        MyPageDto.MyInfoResponse myInfo = myPageService.findMyInfo(memberId, token);
+    @GetMapping("/myInfo")
+    public ResponseEntity getMyInfo(@RequestHeader("Authorization") String token) {
+        Member member = tokenDecryption.getWriterInJWTToken(token);
+        MyPageDto.MyInfoResponse myInfo = myPageService.findMyInfo(member.getMemberId(), token); // token으로 Member 추출
 
         return new ResponseEntity<>(myInfo, HttpStatus.OK);
     }

--- a/src/main/java/com/OmObe/OmO/member/controller/MemberController.java
+++ b/src/main/java/com/OmObe/OmO/member/controller/MemberController.java
@@ -50,9 +50,10 @@ public class MemberController {
     }
 
     // 회원 탈퇴
-    @DeleteMapping("/member/{memberId}")
-    public ResponseEntity deleteMember(@Valid @PathVariable("memberId") @Positive Long memberId){
-        memberService.quitMember(memberId);
+    @DeleteMapping("/member")
+    public ResponseEntity deleteMember(@RequestHeader("Authorization") String token){
+        Member member = tokenDecryption.getWriterInJWTToken(token);
+        memberService.quitMember(member.getMemberId());
 
         return new ResponseEntity<>(HttpStatus.NO_CONTENT);
     }

--- a/src/main/java/com/OmObe/OmO/member/controller/MemberController.java
+++ b/src/main/java/com/OmObe/OmO/member/controller/MemberController.java
@@ -1,11 +1,13 @@
 package com.OmObe.OmO.member.controller;
 
+import com.OmObe.OmO.auth.jwt.TokenDecryption;
 import com.OmObe.OmO.member.dto.MemberDto;
 import com.OmObe.OmO.member.entity.Member;
 import com.OmObe.OmO.member.mapper.MemberMapper;
 import com.OmObe.OmO.member.repository.MemberRepository;
 import com.OmObe.OmO.member.service.MemberService;
 import com.OmObe.OmO.response.ResponseDto;
+import lombok.RequiredArgsConstructor;
 import org.apache.coyote.Response;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;
@@ -18,17 +20,12 @@ import javax.validation.constraints.Positive;
 
 @RestController
 @Validated
+@RequiredArgsConstructor
 public class MemberController {
     private final MemberMapper mapper;
     private final MemberService memberService;
     private final MemberRepository memberRepository;
-
-    @Autowired
-    public MemberController(MemberMapper mapper, MemberService memberService, MemberRepository memberRepository) {
-        this.mapper = mapper;
-        this.memberService = memberService;
-        this.memberRepository = memberRepository;
-    }
+    private final TokenDecryption tokenDecryption;
 
     // 회원 가입
 //    @PostMapping("/signup")
@@ -40,10 +37,11 @@ public class MemberController {
 //    }
 
     // 회원 추가 정보 입력
-    @PostMapping("/memberInfo/{memberId}")
-    public ResponseEntity addMemberInfo(@Valid @PathVariable("memberId") @Positive Long memberId,
+    @PostMapping("/memberInfo")
+    public ResponseEntity addMemberInfo(@RequestHeader("Authorization") String token,
                                         @Valid @RequestBody MemberDto.Post post) {
-        Member member = memberService.addInfo(memberId, post);
+        Member findMember = tokenDecryption.getWriterInJWTToken(token);
+        Member member = memberService.addInfo(findMember.getMemberId(), post);
 
         // ResponseBody에 변경된 회원의 권한 제공
         MemberDto.addInfoResponse addInfoResponse = new MemberDto.addInfoResponse(member.getMemberRole());


### PR DESCRIPTION
- Request Header에 memberId를 넣어 요청을 보내기 위해 로컬 스토리지에 memberId를 저장하여 요청을 보내던 기존 방식은 memberId가 노출되어 임의로 변경될 위험이 있어 Request Header로 memberId를 받는 요청에 대한 코드 수정
- MemberController의 회원 정보 추가 저장, 회원 탈퇴 요청 시 헤더에 토큰만 담아서 요청을 보내면 정상적으로 기능이 동작하도록 수정
- MyPageController의 프로필 이미지 수정, 닉네임 수정, MBTI 수정, 내 정보 조회 요청 시 헤더에 토큰만 담아서 요청을 보내면 정상적으로 기능이 동작하도록 수정